### PR TITLE
Make simple "import lxi" work in FreeBSD, too.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,27 @@ Simple python bindings for liblxi.
 The python bindings implements all of the liblxi API except the discover
 functions.
 
-## Requirements
+## Requirements Linux
 
-Make sure you have python3 and liblxi installed:
+Make sure you have python3 and liblxi installed.
 
+<br />
+
+Install in Linux Debian based (Ubuntu, etc.):
 ```
 sudo apt install liblxi1 python3
 ```
 
+<br />
+
+Install in FreeBSD:
+```
+pkg install liblxi python3
+```
+
 ## Run the example code
 
+First, edit test.py to replace the hardcoded IP address with the IP of your instrument, then run:
 ```
 $ python3 test.py
 Siglent Technologies,SDG2042X,SDG2XCAC2R0212,2.01.01.23R7

--- a/lxi.py
+++ b/lxi.py
@@ -39,7 +39,6 @@ liblxi_paths = ["/usr/lib/x86_64-linux-gnu/liblxi.so.1.0.0",
                 "/usr/lib/x86_64-linux-gnu/liblxi.so.1",
                 "/usr/lib/liblxi.so.1.0.0",
                 "/usr/lib/liblxi.so.1",
-                "/usr/local/liblxi/liblxi.so.1.0.0",
                 "/usr/local/lib/liblxi.so.1",
                 environ.get('LD_PRELOAD', 'none'),
                 ]

--- a/lxi.py
+++ b/lxi.py
@@ -39,6 +39,8 @@ liblxi_paths = ["/usr/lib/x86_64-linux-gnu/liblxi.so.1.0.0",
                 "/usr/lib/x86_64-linux-gnu/liblxi.so.1",
                 "/usr/lib/liblxi.so.1.0.0",
                 "/usr/lib/liblxi.so.1",
+                "/usr/local/liblxi/liblxi.so.1.0.0",
+                "/usr/local/lib/liblxi.so.1",
                 environ.get('LD_PRELOAD', 'none'),
                 ]
 


### PR DESCRIPTION
- added liblxi install instructions for FreeBSD
- added the location for local libs in FreeBSD, so a simple "import lxi" will work without the need to define a system variable