### PR TITLE
Create pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[project]
+version = "1.0"
+name = "lxi"
+description = "Python bindings for liblxi"
+authors = [{name = "Martin Lund", email = "martin.lund@keep-it-simple.com"}]
+license = {text = "BSD"}
+readme = {file = "README.md", content-type = "text/markdown"}
+requires-python = ">=3"
+
+[project.urls]
+Homepage = "https://github.com/lxi-tools/liblxi-python"
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+py-modules = ["lxi"]


### PR DESCRIPTION
Even if the new `pyproject.toml` file doesn't have much content, it allows the `lxi.py` file to be installed using the `pip install` command:

```
pip install git+https://github.com/lxi-tools/liblxi-python
```

This can simplify the dependency management in Python.